### PR TITLE
Filter by missing metadata

### DIFF
--- a/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/manage-pages.component.html
+++ b/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/manage-pages.component.html
@@ -10,7 +10,8 @@
     </button>
   </mat-form-field>
 </div>
-<div class="filterButton" *ngIf="(isWithoutSEO$ | async)">
+<div *ngIf="filterMetadata" class="alert alert-warning alert-panel">There are {{total$ | async}} pages missing critical SEO details.</div>
+  <div class="filterButton"  *ngIf="(isWithoutSEO$ | async)">
   <label>Filter Missing Metadata  </label>
   <label class="switch">
     <input type="checkbox"  (click)="filterByMetadata()" [(ngModel)]="filterMetadata">

--- a/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/manage-pages.component.sass
+++ b/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/manage-pages.component.sass
@@ -83,6 +83,7 @@ mat-icon
    display: flex
    flex-direction: row
    align-items: center
+   justify-content: right
 
 .switch
   position: relative

--- a/Upendo.Modules.DnnPageManager/Settings.html
+++ b/Upendo.Modules.DnnPageManager/Settings.html
@@ -5,6 +5,7 @@
 [JavaScript:{ path: "~/DesktopModules/Upendo.Modules.DnnPageManager/scripts/QuickSettings.js"}]
 
 <div id="QuickSettings-[ModuleContext:ModuleId]" class="dnnForm">
+    <label for="Description"> Look for Metadata In:</label>
     <div class="dnnFormMessage dnnFormInfo">
         <input type="checkbox" id="Title" name="Title" >
         <label for="Title"> Title</label><br>


### PR DESCRIPTION
### Description of PR

This changes will allow to filter the pages by the selected missing metadata

## Changes made

Front-End View

- Update manage-pages.component.html
>Addition of message of number of pages that are missing by SEO

- Filter button right-aligned and located beneath the search textbox.
>Update manage-pages.component.sass

-  Update Settings.html
>Add message: "Look for Metadata In:" in QuickSettings

- Update PagesController.cs
>Title and Description checked by default.
>Changes in filter validations: A new list was added to save the pages that were missing metadata in each of the filters, this will only happen when the  filter button is active, if it is not active, the total list of default pages is returned.

Close #31