### PR TITLE
Update PR Filter by missing metadata

### DIFF
--- a/Upendo.Modules.DnnPageManager/ClientApp/package.json
+++ b/Upendo.Modules.DnnPageManager/ClientApp/package.json
@@ -8,6 +8,7 @@
     "watch": "ng build --watch --configuration development",
     "dev": "ng build --output-hashing none",
     "devwatch": "ng build --output-hashing none --watch",
+    "production": "ng build --output-hashing none --configuration production",
     "test": "ng test"
   },
   "private": true,

--- a/Upendo.Modules.DnnPageManager/Upendo.Modules.DnnPageManager.csproj
+++ b/Upendo.Modules.DnnPageManager/Upendo.Modules.DnnPageManager.csproj
@@ -143,11 +143,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="Module.Build" />
-  <!--PropertyGroup>
+  <PropertyGroup>
     <PreBuildEvent>
       cd $(ProjectDir)ClientApp
-      npm run build
-      ng build REPLACEWITHTWOHYPHENSoutput-hashing none
+      <!-- npm run build
+      ng build REPLACEWITHTWOHYPHENSoutput-hashing none -->
+      ng build --output-hashing none --configuration production 
     </PreBuildEvent>
-  </PropertyGroup-->
+  </PropertyGroup>
 </Project>

--- a/build.bat
+++ b/build.bat
@@ -1,1 +1,1 @@
-build.vs2017.Enterprise.bat
+build.vs2022.Community.bat

--- a/build.vs2022.Community.bat
+++ b/build.vs2022.Community.bat
@@ -1,0 +1,1 @@
+"%programfiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" build.proj /nodeReuse:false /fileLogger /fileLoggerParameters:LogFile=MSBuildLog.txt


### PR DESCRIPTION
### Description of PR

Solving the problem of compiling the ClientApp from the build.bat file

## Changes made
-  Update Upendo.Modules.DnnPageManager.csproj
> I have updated the Upendo.Modules.DnnPageManager.csproj file as indicated, I have uncommented the indicated section so that the Angular build is executed when we execute the build.bat file. I have added the command line to directly execute the build in release mode

-Update package.json in ClientApp
>I noticed that in the package.json file the production environment is not referenced and I have added it. This for when we do the angular build, the generated files are the files in release mode and do not have the numbers that appear before the point as in development.

-Update Build.bat
>I have added a new file "build.vs2022.Community.bat" in this archive to point to MSBuild in VisualStudio 2022. I have also updated the build.bat file to point to this newly added file.

Update PR #92
Close #31 