### PR TITLE
Update 2 PR Filter by missing metadata

### DIFF
--- a/Upendo.Modules.DnnPageManager/Upendo.Modules.DnnPageManager.csproj
+++ b/Upendo.Modules.DnnPageManager/Upendo.Modules.DnnPageManager.csproj
@@ -143,7 +143,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="Module.Build" />
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <PreBuildEvent>
       cd $(ProjectDir)ClientApp
       <!-- npm run build


### PR DESCRIPTION
### Description of PR

Addition of condition in the <PropertyGroup> for it to only run from release mode in VisualStudio. With this change, the ClientApp build will only be executed from VisualStudio when the solution is in release mode only.

## Changes made
- Update Upendo.Modules.DnnPageManager.csproj
>  Change \<PropertyGroup> to \<PropertyGroup Condition="'$(Configuration)'=='Release'">

Update PR#93
Close #31 