### PR TITLE
Fix - Indexed pages and non indexed pages have the same icon

### DIFF
--- a/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/manage-pages.component.html
+++ b/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/manage-pages.component.html
@@ -91,9 +91,9 @@
     <ng-container matColumnDef="indexing">
       <th mat-header-cell *matHeaderCellDef></th>
       <td mat-cell *matCellDef="let element">
-        <mat-icon *ngIf="element.IsIndexed" align="center" title="Page index disabled" class="c-default">zoom_in
+        <mat-icon *ngIf="element.IsAllowedSearch" align="center" (dblclick)="updateIndexing(element, false)" title="Page index enabled">zoom_in
         </mat-icon>
-        <mat-icon *ngIf="!element.IsIndexed" align="center" title="Page index enabled" class="c-default">zoom_out
+        <mat-icon *ngIf="!element.IsAllowedSearch" align="center" (dblclick)="updateIndexing(element, true)" title="Page index disabled">zoom_out
         </mat-icon>
       </td>
     </ng-container>

--- a/Upendo.Modules.DnnPageManager/Components/PagesControllerImpl.cs
+++ b/Upendo.Modules.DnnPageManager/Components/PagesControllerImpl.cs
@@ -243,7 +243,49 @@ namespace Upendo.Modules.DnnPageManager.Components
                 };
             }
         }
+ public Outcome UpdatePageAllowIndex(int portalId, int tabId, bool fieldValue)
+        {
+            try
+            {
+                var tab = TabController.Instance.GetTab(tabId, portalId);
+                if (tab == null)
+                {
+                    return new Outcome()
+                    {
+                        Success = false,
+                        ErrorMessage = Constants.ERROR_PAGE_TABID_INVALID
+                    };
+                }
+               
+                if (fieldValue == true)
+                {
+                    tab.TabSettings["AllowIndex"] = "true";
+                }
 
+                if (fieldValue == false)
+                {
+                    tab.TabSettings["AllowIndex"] = "false";
+                }
+                                
+                TabController.Instance.UpdateTab(tab);
+
+                return new Outcome()
+                {
+                    Success = true,
+                    ErrorMessage = Constants.SUCCESS_UPDATED
+                };
+            }
+            catch (Exception ex)
+            {
+                LogError(ex);
+                Exceptions.LogException(ex);
+                return new Outcome()
+                {
+                    Success = false,
+                    ErrorMessage = string.Format(Constants.ERROR_FORMAT_UPDATE_VALUE, "Allow Index", ex.Message)
+                };
+            }
+        }
         private Outcome UpdateTabUrl(TabInfo tab, int portalId, string fieldValue)
         {
             var portalSettings = new PortalSettings(portalId);

--- a/Upendo.Modules.DnnPageManager/WebAPI/PagesController.cs
+++ b/Upendo.Modules.DnnPageManager/WebAPI/PagesController.cs
@@ -132,7 +132,6 @@ namespace Upendo.Modules.DnnPageManager.Controller
                     IsVisible = p.IsVisible,
                     IsAllowedSearch = p.AllowIndex,
                     IsDisabled = p.DisableLink,
-                    IsIndexed = p.Indexed,
                     HasBeenPublished = p.HasBeenPublished
                 }) : pages.OrderBy(s => s.LocalizedTabName).Select(p => new
                 {
@@ -147,7 +146,6 @@ namespace Upendo.Modules.DnnPageManager.Controller
                     IsVisible = p.IsVisible,
                     IsAllowedSearch = p.AllowIndex,
                     IsDisabled = p.DisableLink,
-                    IsIndexed = p.Indexed,
                     HasBeenPublished = p.HasBeenPublished
                 });
 
@@ -486,7 +484,7 @@ namespace Upendo.Modules.DnnPageManager.Controller
 
                 PagesControllerImpl pageController = new PagesControllerImpl();
 
-                var response = pageController.UpdatePageProperty(portalId, tabId, TabFields.Indexed, indexed.ToString());
+                var response = pageController.UpdatePageAllowIndex(portalId, tabId, indexed);
                 return Request.CreateResponse<dynamic>(HttpStatusCode.OK);
             }
             catch (Exception ex)


### PR DESCRIPTION
### Description of PR.

Solution for Page Manager Issues: Indexed Pages and Non-Indexed Pages Have the Same Icon

## Changes made

1. Update file manage-pages.component.html.
•	Condition change IsIndexed > IsAllowedSearch (The condition that was there is not correct for the expected result.)
•	Addition of the dblclick > "updateIndexing" event to modify the Indexing property from the icon.
•	Change of position of the titles in the icons since they were upside down

2. Update PagesControllers.cs
•	Modification of the "SetPageIndexed" method which previously modified the Indexed property in Model.Page and for this called the "UpdatePageProperty" method in PagesControllerImp. Now it calls a new method "UpdatePageAllowIndex" created in PagesControllerImp with the objective of only modifying the property tab.TabSettings["AllowIndex"] which is what we need.

3. Update PagesControllersImp.cs
•	Addition of a new method in PagesControllerImp. "UpdatePageAllowIndex" was created in with the goal of only modifying the tab.TabSettings["AllowIndex"] property which is what we need.

## Test performed

![Enabled](https://user-images.githubusercontent.com/34067433/210127295-adbd8783-d0b7-4fc3-8faa-dcfa6ab66971.png)

![Disabled](https://user-images.githubusercontent.com/34067433/210127299-28f4cd16-5e04-4bb9-8e66-0b4d0550811f.png)


##
Close #60 