### PR TITLE
Fix - Editing metadata data display clears results

### DIFF
--- a/Upendo.Modules.DnnPageManager/Scripts/QuickSettings.js
+++ b/Upendo.Modules.DnnPageManager/Scripts/QuickSettings.js
@@ -20,6 +20,32 @@ dnnspamodule.quickSettings = function(root, moduleId) {
     }
     service.baseUrl = service.framework.getServiceRoot(service.path);
 
+    var FirstTimeSaveSettings = function () {
+        var deferred = $.Deferred();
+        var params = {
+            title: true,
+            description: true,
+            keywords: false
+        };
+        utils.get("POST", "save", service, params,
+            function (data) {
+                deferred.resolve();
+                location.reload();
+            },
+            function (error, exception) {
+                // fail
+                var deferred = $.Deferred();
+                deferred.reject();
+                alert.danger({
+                    selector: parentSelector,
+                    text: error.responseText,
+                    status: error.status
+                });
+            },
+            function () {
+            });
+        return deferred.promise();
+    };
     var SaveSettings = function () {
         
         var title = $('#Title').is(":checked");
@@ -72,6 +98,17 @@ dnnspamodule.quickSettings = function(root, moduleId) {
                 $('#Description').prop('checked', data.description == "true");
                 $('#Keywords').prop('checked', data.keywords == "true");
                 //$('.myCheckbox')[0].checked = true;
+                var stateModule = localStorage.getItem('stateModule')
+                if (data.title == null && stateModule === "inPage" && $('#loadPageMod').text() === "Loading....") {
+                    window.location.reload();
+                }
+                if (data.title == null && $('#loadPageMod').text() !== "Loading....") {
+                    FirstTimeSaveSettings();
+                }
+                localStorage.setItem('stateModule', "inPage");
+                if ($('#loadPageMod').text() !== "Loading....") {
+                    localStorage.removeItem('stateModule');
+                }
             },
             function (error, exception) {
                 // fail

--- a/Upendo.Modules.DnnPageManager/index.html
+++ b/Upendo.Modules.DnnPageManager/index.html
@@ -24,7 +24,7 @@
 -->
 <base href="[ModuleProperties:rawurl]">
 <app-root>
-    <p>Loading....</p>
+    <p id="loadPageMod">Loading....</p>
 </app-root>
 <script>
     window["Upendo.Modules.DnnPageManager"] = [ModuleProperties:All]


### PR DESCRIPTION
### Description of PR...
Solution for Page Manager Issues: Editing Metadata Data Display Clears Results

## Changes made
1.Update file QuickSettings.js
- Addition of a new Method: "FirstTimeSaveSettings" to save the settings the first time the module is installed and these can be loaded at startup.
- Addition of condition to identify if the module is in Loading status and refresh the page so that it reloads all the data correctly.
- Addition of a condition so that if the module is already installed correctly, remove from localStorage a "stateModule" variable that I had previously saved to know that the module was in a floating state and was not placed within the page as such.

2. Update file index.html
-Addition of a key to the  \<p> tag to be able to check the status of the key in QuickSettings.js and know that the module is starting for the first time and is in the Loading state...

Close #90 

####Test performed
I have created a demo to share the test made with the new updates.
https://www.screencast.com/t/jZXTsV0bXrHd