### PR TITLE
Page manager pagination bug

### DIFF
--- a/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/manage-pages.component.html
+++ b/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/manage-pages.component.html
@@ -87,15 +87,17 @@
         <td mat-cell *matCellDef="let element" data-label="lastUpdated">{{ isNullOrEmpty(element.LastUpdated) }}</td>
       </ng-container>
 
-    <ng-container matColumnDef="indexing">
-      <th mat-header-cell *matHeaderCellDef></th>
-      <td mat-cell *matCellDef="let element">
-        <mat-icon *ngIf="element.IsAllowedSearch" align="center" (dblclick)="updateIndexing(element, false)" title="Page index enabled">zoom_in
-        </mat-icon>
-        <mat-icon *ngIf="!element.IsAllowedSearch" align="center" (dblclick)="updateIndexing(element, true)" title="Page index disabled">zoom_out
-        </mat-icon>
-      </td>
-    </ng-container>
+      <ng-container matColumnDef="indexing">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let element">
+          <mat-icon *ngIf="element.IsAllowedSearch" align="center" (dblclick)="updateIndexing(element, false)"
+            title="Page index enabled">zoom_in
+          </mat-icon>
+          <mat-icon *ngIf="!element.IsAllowedSearch" align="center" (dblclick)="updateIndexing(element, true)"
+            title="Page index disabled">zoom_out
+          </mat-icon>
+        </td>
+      </ng-container>
       <ng-container matColumnDef="settings">
         <th mat-header-cell *matHeaderCellDef></th>
         <td mat-cell *matCellDef="let element" data-label="settings">
@@ -131,12 +133,13 @@
 
     <div ngClass="paginator">
       <div ngClass="mat-paginator">
-        <div style="display: flex; align-items: baseline">
-          <div style="margin-right: 8px">Go to page:</div>
+        <div style="display: flex; align-items: baseline ;margin-top: 8px; margin-right: 30px;">
+          <div style="margin-right: 20px">Go to page:</div>
           <mat-form-field appearance="legacy" style="width: 5vw">
             <input type="number" matInput [(ngModel)]="goToPage" (keydown.enter)="updateGoToPage()"
               autocomplete="off" />
           </mat-form-field>
+          <div>of {{pages}} pages</div>
         </div>
       </div>
       <div>

--- a/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/manage-pages.component.ts
+++ b/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/manage-pages.component.ts
@@ -68,6 +68,8 @@ export class ManagePagesComponent implements OnInit, OnDestroy, AfterViewInit {
 
   filterMetadata = false;
 
+  pages: any = '0';
+
   protected dispose = new Subject<void>();
 
   @ViewChild(MatPaginator) paginator: MatPaginator;
@@ -90,7 +92,9 @@ export class ManagePagesComponent implements OnInit, OnDestroy, AfterViewInit {
   ) {}
 
   ngOnInit(): void {
-    this.filterMetadata = localStorage.getItem("filterMetadata") === "true" ? true : false;
+    this.filterMetadata =
+      localStorage.getItem('filterMetadata') === 'true' ? true : false;
+    this.pages = localStorage.getItem('pages');
     this.store
       .select(PageState.updated)
       .pipe(
@@ -125,18 +129,15 @@ export class ManagePagesComponent implements OnInit, OnDestroy, AfterViewInit {
       .subscribe();
   }
 
-  filterByMetadata():void {
-
+  filterByMetadata(): void {
     this.filterMetadata = !this.filterMetadata;
 
     localStorage.setItem('filterMetadata', JSON.stringify(this.filterMetadata));
 
     this.getPages(false, true);
-
   }
 
-  isNeededFilterByMetadata():void{
-    
+  isNeededFilterByMetadata(): void {
     const portalId = this.context._properties.PortalId;
     const sortType = localStorage.getItem('sortType');
     const sortBy = localStorage.getItem('sortBy');
@@ -147,7 +148,7 @@ export class ManagePagesComponent implements OnInit, OnDestroy, AfterViewInit {
         new GetAllPagesWithoutSEO(
           portalId,
           !!searchValue ? searchValue : this.searchText,
-          this.paginator ? !!searchValue ? 0 : this.paginator.pageIndex : 0,
+          this.paginator ? (!!searchValue ? 0 : this.paginator.pageIndex) : 0,
           this.paginator ? this.paginator.pageSize : 10,
           !!sortBy ? sortBy : this.sort?.active,
           !!sortType ? sortType : this.sort?.direction,
@@ -167,7 +168,7 @@ export class ManagePagesComponent implements OnInit, OnDestroy, AfterViewInit {
           }
         })
       )
-      .subscribe();      
+      .subscribe();
   }
 
   getPages(showClearSearch: boolean, isInit: boolean = false): void {
@@ -179,8 +180,7 @@ export class ManagePagesComponent implements OnInit, OnDestroy, AfterViewInit {
       this.paginator.pageIndex = 0;
     }
 
-    if (isInit)
-      this.paginator.pageIndex = 0;
+    if (isInit) this.paginator.pageIndex = 0;
 
     if (!!this.sort) {
       localStorage.setItem(
@@ -203,7 +203,11 @@ export class ManagePagesComponent implements OnInit, OnDestroy, AfterViewInit {
         new GetAllPages(
           portalId,
           !!searchValue ? searchValue : this.searchText,
-          this.paginator ? !!searchValue || isInit ? 0 : this.paginator.pageIndex : 0,
+          this.paginator
+            ? !!searchValue || isInit
+              ? 0
+              : this.paginator.pageIndex
+            : 0,
           this.paginator ? this.paginator.pageSize : 10,
           !!sortBy ? sortBy : this.sort?.active,
           !!sortType ? sortType : this.sort?.direction,

--- a/Upendo.Modules.DnnPageManager/ClientApp/src/app/state/page.state.ts
+++ b/Upendo.Modules.DnnPageManager/ClientApp/src/app/state/page.state.ts
@@ -154,10 +154,11 @@ export class PageState {
       )
       .pipe(
         tap((x) => {
-          console.log(x.Total > 0);
-          console.log(x);
+          var pages = Math.ceil(x.Total / action.pageSize);
+          localStorage.setItem('pages', pages.toString());
+          console.log('pages', pages);
           patchState({
-            isWithoutSEO: x.Total > 0,            
+            isWithoutSEO: x.Total > 0,
           });
         })
       );

--- a/Upendo.Modules.DnnPageManager/Components/PagesControllerImpl.cs
+++ b/Upendo.Modules.DnnPageManager/Components/PagesControllerImpl.cs
@@ -50,7 +50,7 @@ namespace Upendo.Modules.DnnPageManager.Components
         }
 
         public IEnumerable<Page> GetPagesList(int portalId, out int total, string searchKey = "", int pageIndex = -1, int pageSize = 10,
-                                            string sortBy = "", string sortType = "", bool? deleted = false)
+                                            string sortBy = "", string sortType = "", bool? deleted = false,bool? getAllPages=false)
         {
             try
             {
@@ -114,7 +114,8 @@ namespace Upendo.Modules.DnnPageManager.Components
                 finalList.AddRange(pages);
 
                 total = finalList.Count;
-                return pageIndex == -1 || pageSize == -1 ? finalList : finalList.Skip(pageIndex * pageSize).Take(pageSize);
+               
+                return pageIndex == -1 || pageSize == -1 ? finalList : getAllPages==true? finalList : finalList.Skip(pageIndex * pageSize).Take(pageSize);
             }
             catch (Exception ex)
             {
@@ -126,7 +127,7 @@ namespace Upendo.Modules.DnnPageManager.Components
 
         }
 
-        public IEnumerable<Module> GetPageModules(int portalId, int tabId)
+      public IEnumerable<Module> GetPageModules(int portalId, int tabId)
         {
             try
             {
@@ -385,6 +386,51 @@ namespace Upendo.Modules.DnnPageManager.Components
                 LogError(e);
                 throw;
             }
+        }
+        public IEnumerable<Page> GetPagesMissingMetadata(IEnumerable<Model.Page> pages, ModuleInfo ActiveModule, bool? filterMetadata = false)
+        {
+          var pagesMissingMetadata = new List<Model.Page>();
+            if (filterMetadata.HasValue && ActiveModule.ModuleSettings.Count > 1)
+            {
+                if (filterMetadata.Value)
+                {
+                    if (ActiveModule.ModuleSettings[Constants.QuickSettings.MODSETTING_Title].ToString().Equals(Constants.QuickSettings.MODSETTING_DefaultTrue))
+                    {
+                        var filterTitle = pages.Where(tab => string.IsNullOrEmpty(tab.Title));
+                        foreach (var item in filterTitle)
+                        {
+                            if (!pagesMissingMetadata.Any(s => s.KeyID == item.KeyID))
+                            {
+                                pagesMissingMetadata.Add(item);
+                            }
+                        }
+                    }
+                    if (ActiveModule.ModuleSettings[Constants.QuickSettings.MODSETTING_Description].ToString().Equals(Constants.QuickSettings.MODSETTING_DefaultTrue))
+                    {
+                        var filterDescription = pages.Where(tab => string.IsNullOrEmpty(tab.Description));
+                        foreach (var item in filterDescription)
+                        {
+                            if (!pagesMissingMetadata.Any(s => s.KeyID == item.KeyID))
+                            {
+                                pagesMissingMetadata.Add(item);
+                            }
+                        }
+
+                    }
+                    if (ActiveModule.ModuleSettings[Constants.QuickSettings.MODSETTING_Keywords].ToString().Equals(Constants.QuickSettings.MODSETTING_DefaultTrue))
+                    {
+                        var filterKeyWords = pages.Where(tab => string.IsNullOrEmpty(tab.KeyWords));
+                        foreach (var item in filterKeyWords)
+                        {
+                            if (!pagesMissingMetadata.Any(s => s.KeyID == item.KeyID))
+                            {
+                                pagesMissingMetadata.Add(item);
+                            }
+                        }
+                    }
+                }
+            }
+            return pagesMissingMetadata.ToList();
         }
 
         private static void LogError(Exception ex)


### PR DESCRIPTION
The pull request resolves the existing error in the PageManager pagination. The next page button is already enabled, it lets you know the total number of items there are as well as the total number of pages and you can use the "go to page" correctly. Giving solution to the problem https://github.com/UpendoVentures/Upendo-Dnn-PageManager/issues/101

## Changes made
- I modified the GetPagesList method to get the total number of pages on the site by storing it in the allPages variable.
- I added a new parameter (getAllPages:true) to reuse the existing method that was used to get the paginated result.
- I removed the implemented method to filter pages missing metadata to reuse the same implementation to get the paginated 
  result and total pages. 
- I created the new method in PagesControllerImpl called GetPagesMissingMetadata.
- I added the new parameter "getAllPages" to get the total number of pages if the value is true.
- I created the method to filter pages missing metadata to reuse the same implementation to get the paged result or total 
  pages as needed.
- And show total pages in view, and I changed the style to make it look better. I got the total pages from local storage and 
  saved it to a variable to display its value in the view.


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
Solve the issue 101
https://github.com/UpendoVentures/Upendo-Dnn-PageManager/issues/101

Close #