### PR TITLE
Remove inline css

### DIFF
--- a/Upendo.Modules.DnnPageManager/ClientApp/src/app/app.component.html
+++ b/Upendo.Modules.DnnPageManager/ClientApp/src/app/app.component.html
@@ -1,4 +1,4 @@
-<div style="text-align:center">
+<div class="text_center">
   <h2>
     {{ title }}
   </h2>

--- a/Upendo.Modules.DnnPageManager/ClientApp/src/app/app.component.sass
+++ b/Upendo.Modules.DnnPageManager/ClientApp/src/app/app.component.sass
@@ -1,6 +1,8 @@
 h2
-   font-size: 16px
-   font-weight: 700
-   color: #000000
-   text-align: left
-   
+  font-size: 16px
+  font-weight: 700
+  color: #000000
+  text-align: left
+
+.text_center
+  text-align: center

--- a/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/edit-permissions-dialog/edit-permissions-dialog.component.html
+++ b/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/edit-permissions-dialog/edit-permissions-dialog.component.html
@@ -11,16 +11,14 @@
     <ng-container matColumnDef="view">
       <th mat-header-cell *matHeaderCellDef width="100">View</th>
       <td mat-cell *matCellDef="let element" align="center">
-        <mat-checkbox [checked]='element.View' disableRipple disabled="true"
-        ></mat-checkbox>
+        <mat-checkbox [checked]='element.View' disableRipple disabled="true"></mat-checkbox>
       </td>
     </ng-container>
 
     <ng-container matColumnDef="edit">
       <th mat-header-cell *matHeaderCellDef width="100">Edit</th>
       <td mat-cell *matCellDef="let element" align="center">
-        <mat-checkbox [checked]='element.Edit' disableRipple disabled="true"
-        ></mat-checkbox>
+        <mat-checkbox [checked]='element.Edit' disableRipple disabled="true"></mat-checkbox>
       </td>
     </ng-container>
 
@@ -29,7 +27,7 @@
   </table>
   <table>
     <tr *ngIf="(rolePermissions$ | async)?.length === 0">
-      <td style="text-align: center" [attr.colspan]="displayedRoleColumns.length">
+      <td class="text_center" [attr.colspan]="displayedRoleColumns.length">
         No Records Found!
       </td>
     </tr>
@@ -49,16 +47,14 @@
     <ng-container matColumnDef="view">
       <th mat-header-cell *matHeaderCellDef width="100">View</th>
       <td mat-cell *matCellDef="let element" align="center">
-        <mat-checkbox [checked]='element.View' disableRipple disabled="true"
-        ></mat-checkbox>
+        <mat-checkbox [checked]='element.View' disableRipple disabled="true"></mat-checkbox>
       </td>
     </ng-container>
 
     <ng-container matColumnDef="edit">
       <th mat-header-cell *matHeaderCellDef width="100">Edit</th>
       <td mat-cell *matCellDef="let element" align="center">
-        <mat-checkbox [checked]='element.Edit' disableRipple disabled="true"
-        ></mat-checkbox>
+        <mat-checkbox [checked]='element.Edit' disableRipple disabled="true"></mat-checkbox>
       </td>
     </ng-container>
 
@@ -67,7 +63,7 @@
   </table>
   <table>
     <tr *ngIf="(userPermissions$ | async)?.length === 0">
-      <td class="info" style="text-align: center" [attr.colspan]="displayedUserColumns.length">
+      <td class="info text_center" [attr.colspan]="displayedUserColumns.length">
         No Records Found!
       </td>
     </tr>
@@ -75,21 +71,10 @@
 </div>
 
 <div mat-dialog-actions class="dialog-action">
-<a
-    class="button"
-    mat-flat-button
-    (click)="cancel()"
-    disableRipple
-  >
+  <a class="button" mat-flat-button (click)="cancel()" disableRipple>
     Cancel
-</a>
-<a
-    class="button"
-    mat-flat-button
-    (click)="!isEditDisabled && edit()"
-    disableRipple
-    [disabled]="isEditDisabled"
-  >
+  </a>
+  <a class="button" mat-flat-button (click)="!isEditDisabled && edit()" disableRipple [disabled]="isEditDisabled">
     Edit
-</a>
+  </a>
 </div>

--- a/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/edit-permissions-dialog/edit-permissions-dialog.component.sass
+++ b/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/edit-permissions-dialog/edit-permissions-dialog.component.sass
@@ -1,94 +1,96 @@
 table
- width: 100%
+  width: 100%
 
 th.mat-header-cell
-   font-size: 12px
-   font-weight: 700
-   color: #46292B
-   padding: 8px
-   text-transform: uppercase
-   &:not(:first-child)
-      text-align: center
+  font-size: 12px
+  font-weight: 700
+  color: #46292B
+  padding: 8px
+  text-transform: uppercase
+  &:not(:first-child)
+    text-align: center
 
 td
-   &.mat-cell
-      font-size: 12px
-      padding: 8px
-      /* cursor: pointer */
-      color: #000000
-   mat-checkbox
-      cursor: not-allowed
+  &.mat-cell
+    font-size: 12px
+    padding: 8px
+  //  cursor: pointer
+    color: #000000
+  //  mat-checkbox
+    cursor: not-allowed
 
-mat-icon
-   font-size: 18px
-   width: 18px
-   height: 18px
-   margin-right: 7px
-   vertical-align: middle
-   cursor: pointer
+// mat-icon
+//     font-size: 18px
+//     width: 18px
+//     height: 18px
+//     margin-right: 7px
+//     vertical-align: middle
+//     cursor: pointer
 
 h2
-   font-size: 16px
-   font-weight: 700
-   color: #000000
-   text-align: left
+  font-size: 16px
+  font-weight: 700
+  color: #000000
+  text-align: left
 
 .mat-dialog-actions
-   justify-content: center
-  
-.button
-   border: 1px solid #3f51b5
-   height: 34px
-   padding: 0 22px
-   font-size: 14px
-   line-height: 34px
-   color: #3f51b5
-   background: #FFFFFF
-   border-radius: 3px
-   cursor: pointer
+  justify-content: center
 
 .button
-   &:hover,
-   &:focus,
-   &:visited
-      color: #3f51b5!important
-      background: #f5f8fa!important
+  border: 1px solid #3f51b5
+  height: 34px
+  padding: 0 22px
+  font-size: 14px
+  line-height: 34px
+  color: #3f51b5
+  background: #FFFFFF
+  border-radius: 3px
+  cursor: pointer
 
 .button
-   &:disabled,
-   &[disabled],
-   &:disabled:hover,
-   &:disabled:focus,
-   &:disabled:visited
-      border: 1px solid #999999 !important
-      background-color: rgba(0,0,0,.12) !important
-      color: #666666 !important
-      cursor: not-allowed !important
-      pointer-events: none
+  &:hover,
+  &:focus,
+  &:visited
+    color: #3f51b5!important
+    background: #f5f8fa!important
+
+.button
+  &:disabled,
+  &[disabled],
+  &:disabled:hover,
+  &:disabled:focus,
+  &:disabled:visited
+    border: 1px solid #999999 !important
+    background-color: rgba(0,0,0,.12) !important
+    color: #666666 !important
+    cursor: not-allowed !important
+    pointer-events: none
 
 a
-   &:hover,
-   &:focus,
-   &:visited
-      text-decoration: none
-      font-family: Roboto, "Helvetica Neue", sans-serif
-      background: #FFFFFF
-
+  &:hover,
+  &:focus,
+  &:visited
+    text-decoration: none
+    font-family: Roboto, "Helvetica Neue", sans-serif
+    background: #FFFFFF
 
 ::ng-deep .mat-checkbox-checked
-   &.mat-accent
-      .mat-checkbox-background 
-         background-color: #d3d3d3
+  &.mat-accent
+    .mat-checkbox-background
+      background-color: #d3d3d3
 
-::ng-deep 
-   .mat-checkbox-checkmark-path 
-      stroke: #707070 !important
-    
-   .mat-button-focus-overlay
-      background-color: transparent
+::ng-deep
+  .mat-checkbox-checkmark-path
+    stroke: #707070 !important
+
+  .mat-button-focus-overlay
+    background-color: transparent
 
 .table-container
-   margin-bottom: 20px
+  margin-bottom: 20px
 
-.info 
-   padding: 10px 0
+.info
+  padding: 10px 0
+
+.text_center
+  text-align: center

--- a/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/manage-pages.component.html
+++ b/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/manage-pages.component.html
@@ -133,9 +133,9 @@
 
     <div ngClass="paginator">
       <div ngClass="mat-paginator">
-        <div style="display: flex; align-items: baseline ;margin-top: 8px; margin-right: 30px;">
-          <div style="margin-right: 20px">Go to page:</div>
-          <mat-form-field appearance="legacy" style="width: 5vw">
+        <div class="paginator">
+          <div class="go_to_page">Go to page:</div>
+          <mat-form-field appearance="legacy" class="mat_form_field">
             <input type="number" matInput [(ngModel)]="goToPage" (keydown.enter)="updateGoToPage()"
               autocomplete="off" />
           </mat-form-field>

--- a/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/manage-pages.component.sass
+++ b/Upendo.Modules.DnnPageManager/ClientApp/src/app/components/manage-pages/manage-pages.component.sass
@@ -148,3 +148,15 @@ input
 
   &:before
     border-radius: 50%
+
+.paginator
+  display: flex
+  align-items: baseline
+  margin-top: 8px
+  margin-right: 30px
+
+.go_to_page
+  margin-right: 20px
+
+.mat_form_field
+  width: 5vw


### PR DESCRIPTION
Defines all the CSS styling in the CSS files making it easier to maintain the site.

## Changes made

- I changed all the "style" tags to "class", to remove the css inside the html page.
- I created class "text_center", to remove the CSS from the html page.
- I created the "text_center" class, to remove the css from the html page. I commented out mat-icon because it was wrong and didn't meet any objective, besides that they caused problems when compiling the ClientApp, just like the mat-checkbox property.
- I created "paginator", "go_to_page" and "mat_form_field" classes, to remove the CSS from the HTML page.

## PR Template Checklist

- [ X] Fixes Bug
- [ ] Feature solution
- [ ] Other

## Please mark which issue is solved
https://github.com/UpendoVentures/Upendo-Dnn-PageManager/issues/107
